### PR TITLE
Fixes #15, using IDs instead of names

### DIFF
--- a/etc/backend/opennebula/model/infrastructure/network.json
+++ b/etc/backend/opennebula/model/infrastructure/network.json
@@ -8,6 +8,9 @@
                 "org":{
                     "opennebula":{
                         "network":{
+                            "id":{
+                                "Description":"ID of the virtual network"
+                            },
                             "bridge":{
                                 "Description":"Name of the physical bridge in the physical host where the VM should connect its network interface"
                             },

--- a/etc/backend/opennebula/model/infrastructure/networkinterface.json
+++ b/etc/backend/opennebula/model/infrastructure/networkinterface.json
@@ -3,7 +3,7 @@
         {
             "term":"networkinterface",
             "scheme":"http://opennebula.org/occi/infrastructure#",
-            "title":"OpenNebula specific Storagelink attributes",
+            "title":"OpenNebula specific Networkinterface attributes",
             "attributes":{
                 "org":{
                     "opennebula":{

--- a/etc/backend/opennebula/model/infrastructure/storage.json
+++ b/etc/backend/opennebula/model/infrastructure/storage.json
@@ -8,6 +8,9 @@
                 "org":{
                     "opennebula":{
                         "storage":{
+                            "id":{
+                                 "Description":"ID of the storage element"
+                            },
                             "type":{
                                 "Description":"Type of the image. If omitted, the default value is the one defined in oned.conf (install default is OS).",
                                 "Pattern": "OS|CDROM|DATABLOCK"

--- a/etc/backend/opennebula/one_templates/compute.erb
+++ b/etc/backend/opennebula/one_templates/compute.erb
@@ -38,7 +38,8 @@ OS = [
 <% @compute.links.select {|link| link.kind == "http://schemas.ogf.org/occi/infrastructure#storagelink"}.each do |storagelink| %>
 DISK = [
     <% if restricted.include? "SOURCE" %>
-	IMAGE 	= <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#storage").entities.select {|storage| storage.id == storagelink.target.split('/').last}.first.title.inspect %>
+	<%# IMAGE 	= <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#storage").entities.select {|storage| storage.id == storagelink.target.split('/').last}.first.title.inspect %>
+        IMAGE_ID = <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#storage").entities.select {|storage| storage.id == storagelink.target.split('/').last}.first.attributes.org!.opennebula!.storage!.id %>
     <% else %>
     TYPE    = "OS",
     SOURCE  = "<%= storagelink.target %>"
@@ -59,7 +60,8 @@ DISK = [
 <%# Links to networks %>
 <% @compute.links.select {|link| link.kind == "http://schemas.ogf.org/occi/infrastructure#networkinterface"}.each do |networkinterface| %>
 NIC = [
-    NETWORK   = <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#network").entities.select {|network| network.id == networkinterface.target.split('/').last}.first.title.inspect %>
+    <%# NETWORK   = <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#network").entities.select {|network| network.id == networkinterface.target.split('/').last}.first.title.inspect %>
+    NETWORK_ID = <%= @model.get_by_id("http://schemas.ogf.org/occi/infrastructure#network").entities.select {|network| network.id == networkinterface.target.split('/').last}.first.attributes.org!.opennebula!.network!.id %> 
 
     <% if @compute.attributes.occi!.networkinferface!.address %>
     ,IP        = <%= @compute.attributes.occi!.networkinferface!.address %>

--- a/etc/backend/opennebula/one_templates/network.erb
+++ b/etc/backend/opennebula/one_templates/network.erb
@@ -1,3 +1,4 @@
+ID              = <%= @network.attributes.org!.opennebula!.network!.id %>
 OCCI_ID         = <%= @network.id %>
 NAME            = <%= @network.title.inspect if @network.title %>
 DESCRIPTION     = <%= @network.summary.inspect if @network.summary %>

--- a/etc/backend/opennebula/one_templates/storage.erb
+++ b/etc/backend/opennebula/one_templates/storage.erb
@@ -1,3 +1,4 @@
+<%="ID           =" + @storage.attributes.org!.opennebula!.storage!.id %>
 <%="NAME           =" + @storage.title.inspect if @storage.title %>
 <%="DESCRIPTION    =" + @storage.summary if @storage.summary %>
 <% if @storage.attributes.org!.opennebula!.storage!.type %>

--- a/lib/occi/backend/opennebula/network.rb
+++ b/lib/occi/backend/opennebula/network.rb
@@ -62,6 +62,7 @@ module OCCI
           network.attributes.occi!.network!.allocation = "static" if backend_object['TEMPLATE/TYPE'].downcase == "fixed"
           network.attributes.occi!.network!.allocation = "dynamic" if backend_object['TEMPLATE/TYPE'].downcase == "ranged"
 
+          network.attributes.org!.opennebula!.network!.id = backend_object['ID'] if backend_object['ID']
           network.attributes.org!.opennebula!.network!.vlan = backend_object['TEMPLATE/VLAN'] if backend_object['TEMPLATE/VLAN']
           network.attributes.org!.opennebula!.network!.phydev = backend_object['TEMPLATE/PHYDEV'] if backend_object['TEMPLATE/PHYDEV']
           network.attributes.org!.opennebula!.network!.bridge = backend_object['TEMPLATE/BRIDGE'] if backend_object['TEMPLATE/BRIDGE']

--- a/lib/occi/backend/opennebula/storage.rb
+++ b/lib/occi/backend/opennebula/storage.rb
@@ -57,6 +57,7 @@ module OCCI
 
           storage.attributes.occi!.storage!.size = backend_object['TEMPLATE/SIZE'].to_f/1000 if backend_object['TEMPLATE/SIZE']
 
+          storage.attributes.org!.opennebula!.storage!.id = backend_object['ID'] if backend_object['ID']
           storage.attributes.org!.opennebula!.storage!.type = backend_object['TEMPLATE/TYPE'] if backend_object['TEMPLATE/TYPE']
           storage.attributes.org!.opennebula!.storage!.persistent = backend_object['TEMPLATE/PERSISTENT'] if backend_object['TEMPLATE/PERSISTENT']
           storage.attributes.org!.opennebula!.storage!.dev_prefix = backend_object['TEMPLATE/DEV_PREFIX'] if backend_object['TEMPLATE/DEV_PREFIX']


### PR DESCRIPTION
Issue #15 was caused by a bug in OpenNebula causing
VirtualMachineAllocate errors when referencing storage
and network resources in VM templates by name instead
of ID. I've added network and storage IDs as attributes
in infrastructure models, one_templates and ON backend.
