### PR TITLE
Added network address information to compute

### DIFF
--- a/etc/backend/opennebula/model/infrastructure/compute.json
+++ b/etc/backend/opennebula/model/infrastructure/compute.json
@@ -30,6 +30,9 @@
                             },
                             "boot":{
                                 "Description":"boot device type: hd,fd,cdrom ,network"
+                            },
+                            "ip":{
+                                "Description":"IP addresses of all network interfaces separated by '|'"
                             }
                         }
                     }

--- a/lib/occi/backend/opennebula/compute.rb
+++ b/lib/occi/backend/opennebula/compute.rb
@@ -69,6 +69,14 @@ module OCCI
           compute.attributes.org!.opennebula!.compute!.kernel_cmd = backend_object['TEMPLATE/KERNEL_CMD'] if backend_object['TEMPLATE/KERNEL_CMD']
           compute.attributes.org!.opennebula!.compute!.bootloader = backend_object['TEMPLATE/BOOTLOADER'] if backend_object['TEMPLATE/BOOTLOADER']
           compute.attributes.org!.opennebula!.compute!.boot = backend_object['TEMPLATE/BOOT'] if backend_object['TEMPLATE/BOOT']
+          
+          compute.attributes.org!.opennebula!.compute!.ip = ""
+          backend_object.each('TEMPLATE/NIC') do |nic|
+            compute.attributes.org!.opennebula!.compute!.ip << nic['IP']
+            compute.attributes.org!.opennebula!.compute!.ip << '|'
+          end if backend_object['TEMPLATE/NIC']
+
+          compute.attributes.org!.opennebula!.compute!.ip.chomp!("|")
 
           compute.check(@model)
 


### PR DESCRIPTION
IP address of an active network interface is now available as
"compute.attributes.org.opennebula.compute.ip"
in each compute resource. Multiple addresses (from multiple
NICs per VM) use '|' as a separator, e.g. "10.0.0.1|192.168.1.1"
