### PR TITLE
ON backend fixes

### DIFF
--- a/etc/backend/opennebula/opennebula.json
+++ b/etc/backend/opennebula/opennebula.json
@@ -10,7 +10,7 @@
                                 "endpoint":"http://localhost:2633/RPC2",
                                 "admin":"occi",
                                 "password":"occi",
-                                "scheme":"http://my.occi.service/"
+                                "scheme":"http://my.occi.service"
                             }
                         }
                     }

--- a/lib/occi/backend/opennebula.rb
+++ b/lib/occi/backend/opennebula.rb
@@ -254,7 +254,7 @@ module OCCI
           related = %w|http://schemas.ogf.org/occi/infrastructure#os_tpl|
           term    = backend_object['NAME'].downcase.chomp.gsub(/\W/, '_')
           # TODO: implement correct schema for service provider
-          scheme  = self.attributes.info.rocci.backend.opennebula.scheme + "occi/infrastructure/os_tpl#"
+          scheme  = self.attributes.info.rocci.backend.opennebula.scheme + "/occi/infrastructure/os_tpl#"
           title   = backend_object['NAME']
           mixin   = OCCI::Core::Mixin.new(scheme, term, title, nil, related)
           @model.register(mixin)


### PR DESCRIPTION
- Removed trailing slash in ON backend configuration
- Fixed ON template handling, users don't need to own
  or have manage rights on the templates to instantiate
  them
